### PR TITLE
Update and rename Week4-App1.sln to Esperance.sln

### DIFF
--- a/Esperance.sln
+++ b/Esperance.sln
@@ -1,7 +1,7 @@
 Microsoft Visual Studio Solution File, Format Version 12.01
 # Rubie Nunnoo 23703007
 VisualStudioVersion = 15.0.26430.17
-MinimumVisualStudioVersion = 10.0.40219.2
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Esperance", "Esperance\Esperance.csproj", "{AC1441DB-5016-424F-A271-A5E31A214638}"
 EndProject
 Global

--- a/Esperance.sln
+++ b/Esperance.sln
@@ -1,8 +1,8 @@
-Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26430.16
-MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Week4-App1", "Week4-App1\Week4-App1.csproj", "{AC1441DB-5016-424F-A271-A5E31A214638}"
+Microsoft Visual Studio Solution File, Format Version 12.01
+# Rubie Nunnoo 23703007
+VisualStudioVersion = 15.0.26430.17
+MinimumVisualStudioVersion = 10.0.40219.2
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Esperance", "Esperance\Esperance.csproj", "{AC1441DB-5016-424F-A271-A5E31A214638}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
Rename Week4-App1.sln to Esperance.sln
Reason: the name Esperance easier to remember and is more natural. 

Update the file format version from 12.00 to 12.01
Reason: upgrades for the file format is available

Update VisualStudioVersion from 15.0.26430.16 toVisualStudioVersion = 15.0.26430.17
Reason: In case the file format version is updated to 12.01, the software version should be updated as well.

Author details: Rubie Nunnoo 23703007
